### PR TITLE
add credits text, adjust controls text positioning, adjust styling of game over text

### DIFF
--- a/assets/locale/en_US.json
+++ b/assets/locale/en_US.json
@@ -7,5 +7,6 @@
     "introText": "Japan, 1467.\n\nYour forces are on the brink of defeat. Desperation drives you to unsheathe an ancient relic. With a swift slash, you cut it open.\n\nThe relic releases ancient spirits, possesing foe and ally alike.\n\nIt also throws you into a familiar land in a distant future, where the possesed soldiers still roam.\n\nYou failed Japan and condemned the world.\n\nAs the last shogun, your final duty is clear: grant them an honorable death.\n\nThis is your last stand.",
     "pausedText": "PAUSED",
     "controlsText": "Controls\nArrow keys or WASD     Player movement\nSpace or left click          Attack\n1/2/3/4/5\t\t\t                   Switch equipped weapon\nEscape\t\t\t\t\t                   Pause/unpause\nEnter\t\t\t\t\t\t                    Start next wave",
+    "creditsText": "CS345 Fall 2024 project  |  Shogun's Last Stand  |  by Jared Gonzalez, Joey Pabalan, Johnny Urias, Joseph Kabesha, and Tyler Avery",
     "GameOverText": "GAME OVER"
 }

--- a/modules/classes/Arena.js
+++ b/modules/classes/Arena.js
@@ -331,8 +331,7 @@ class Arena {
         draw: function() {
           background(0, 235);
 
-          stroke(255, 255, 255);
-          strokeWeight(1);
+          noStroke();
           fill(255, 0, 0);
           textSize(150);
           textAlign(CENTER, CENTER);
@@ -344,6 +343,8 @@ class Arena {
           text(`${ui.strings.scoreText}: ${ui.arena.score}`, arena.width>>1, arena.height - (Math.round(arena.width / Math.pow(2, 2.25))));
           text(`${ui.strings.highScoreText}: ${ui.arena.highscore}`, arena.width>>1, arena.height - (Math.round(arena.width / Math.pow(2, 2.50))));
 
+          stroke(255, 255, 255);
+          strokeWeight(1);
           fill(255, 255, 255);
           text("Press Enter to play again", arena.width>>1, arena.height - (Math.round(arena.width / Math.pow(2, 3.5))));
         } 
@@ -442,7 +443,10 @@ class Arena {
           text(assets.strings.pausedText, arena.width>>1, arena.height>>3);
           textSize(25);
           textAlign(LEFT, TOP);
-          text(assets.strings.controlsText, arena.width>>2, arena.height>>2);
+          text(assets.strings.controlsText, arena.width*0.35, arena.height>>2);
+          textAlign(LEFT, BOTTOM);
+          textSize(18);
+          text(assets.strings.creditsText, 0, arena.height);
         }
       });
     }


### PR DESCRIPTION
 - added credits to bottom of pause menu (names are in alphabetical order)
 - moved controls text slightly
 - red text in game over screen has been noStroke'd to look better and not have a white outline